### PR TITLE
FIX for gcc-8

### DIFF
--- a/src/complex_block_tridiagonal_linear_systems_solver.f90
+++ b/src/complex_block_tridiagonal_linear_systems_solver.f90
@@ -749,14 +749,14 @@ contains
 
         ! Dummy arguments
         class(ComplexGeneralizedCyclicReductionUtility), intent(inout) :: self
-        integer(ip),      intent(out)   :: ierror
-        real(wp),         intent(in)    :: an(:)
-        real(wp),         intent(in)    :: bn(:)
-        real(wp),         intent(in)    :: cn(:)
-        real(wp), target, intent(inout) :: b(:)
-        real(wp),         intent(inout) :: ah(:)
-        real(wp),         intent(inout) :: bh(:)
-        complex(wp),      intent(inout) :: bc(:)
+        integer(ip),                  intent(out)   :: ierror
+        real(wp),                     intent(in)    :: an(:)
+        real(wp),                     intent(in)    :: bn(:)
+        real(wp),                     intent(in)    :: cn(:)
+        real(wp), target, contiguous, intent(inout) :: b(:)
+        real(wp),                     intent(inout) :: ah(:)
+        real(wp),                     intent(inout) :: bh(:)
+        complex(wp),                  intent(inout) :: bc(:)
 
         ! Local variables
         integer(ip) :: j, iif, kdo, l, ir, i2, i4


### PR DESCRIPTION
Hi, this a fix for the latest gfortran release (8.1.0)

Without this patch, fishpack fails to build with the following error:
```Fortran
complex_block_tridiagonal_linear_systems_solver.f90:896:34:

                     bh_arg(1:) => b(j2:)
                                  1
Error: Assignment to contiguous pointer from non-contiguous target at (1)
```